### PR TITLE
Expose setMarkerInfo and modify KML parser

### DIFF
--- a/library/src/com/google/maps/android/kml/AbsKmlRenderer.java
+++ b/library/src/com/google/maps/android/kml/AbsKmlRenderer.java
@@ -548,7 +548,7 @@ public abstract class AbsKmlRenderer {
    *
    * @param style Style to apply
    */
-  private void setMarkerInfoWindow(KmlStyle style, Marker marker,
+  protected void setMarkerInfoWindow(KmlStyle style, Marker marker,
                                    final KmlPlacemark placemark) {
     boolean hasName = placemark.hasProperty("name");
     boolean hasDescription = placemark.hasProperty("description");

--- a/library/src/com/google/maps/android/kml/KmlFeatureParser.java
+++ b/library/src/com/google/maps/android/kml/KmlFeatureParser.java
@@ -24,7 +24,9 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
 
     private final static int LATITUDE_INDEX = 1;
 
-    private final static String PROPERTY_REGEX = "name|description|visibility|open|address|phoneNumber";
+    private final static String PROPERTY_REGEX = "name|visibility|open|address|phoneNumber";
+
+    private final static String DESCRIPTION_REGEX = "description";
 
     private final static String BOUNDARY_REGEX = "outerBoundaryIs|innerBoundaryIs";
 
@@ -48,6 +50,7 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
         KmlStyle inlineStyle = null;
         HashMap<String, String> properties = new HashMap<String, String>();
         KmlGeometry geometry = null;
+        String description = null;
         int eventType = parser.getEventType();
         while (!(eventType == END_TAG && parser.getName().equals("Placemark"))) {
             if (eventType == START_TAG) {
@@ -57,6 +60,8 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
                     geometry = createGeometry(parser, parser.getName());
                 } else if (parser.getName().matches(PROPERTY_REGEX)) {
                     properties.put(parser.getName(), parser.nextText());
+                } else if (parser.getName().matches(DESCRIPTION_REGEX)) {
+                    description = parser.nextText();
                 } else if (parser.getName().equals(EXTENDED_DATA)) {
                     properties.putAll(setExtendedDataProperties(parser));
                 } else if (parser.getName().equals(STYLE_TAG)) {
@@ -65,7 +70,7 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
             }
             eventType = parser.next();
         }
-        return new KmlPlacemark(geometry, styleId, inlineStyle, properties);
+        return new KmlPlacemark(geometry, styleId, inlineStyle, properties, description);
     }
 
     /**

--- a/library/src/com/google/maps/android/kml/KmlPlacemark.java
+++ b/library/src/com/google/maps/android/kml/KmlPlacemark.java
@@ -1,6 +1,7 @@
 package com.google.maps.android.kml;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a placemark which is either a {@link com.google.maps.android.kml.KmlPoint},
@@ -17,6 +18,8 @@ public class KmlPlacemark {
 
     private final KmlStyle mInlineStyle;
 
+    private final String description;
+
     private HashMap<String, String> mProperties;
 
     /**
@@ -28,6 +31,20 @@ public class KmlPlacemark {
      */
     public KmlPlacemark(KmlGeometry geometry, String style, KmlStyle inlineStyle,
             HashMap<String, String> properties) {
+        this(geometry, style, inlineStyle, properties, null);
+    }
+
+    /**
+     * Creates a new KmlPlacemark object
+     *
+     * @param geometry    geometry object to store
+     * @param style       style id to store
+     * @param properties  properties hashmap to store
+     * @param description placemark description
+     */
+    public KmlPlacemark(KmlGeometry geometry, String style, KmlStyle inlineStyle,
+                        HashMap<String, String> properties, String description) {
+        this.description = description;
         mProperties = new HashMap<String, String>();
         mGeometry = geometry;
         mStyle = style;
@@ -58,7 +75,7 @@ public class KmlPlacemark {
      *
      * @return property entry set
      */
-    public Iterable getProperties() {
+    public Iterable<Map.Entry<String, String>> getProperties() {
         return mProperties.entrySet();
     }
 
@@ -98,6 +115,15 @@ public class KmlPlacemark {
      */
     public boolean hasProperties() {
         return mProperties.size() > 0;
+    }
+
+    /**
+     * Gets the placemark description (not from ExtraData fields).
+     *
+     * @return the placemark description
+     */
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/library/tests/src/com/google/maps/android/kml/KmlFeatureParserTest.java
+++ b/library/tests/src/com/google/maps/android/kml/KmlFeatureParserTest.java
@@ -73,7 +73,7 @@ public class KmlFeatureParserTest extends ActivityTestCase {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_nested_multigeometry);
         KmlPlacemark feature = KmlFeatureParser.createPlacemark(xmlPullParser);
         assertEquals(feature.getProperty("name"), "multiPointLine");
-        assertEquals(feature.getProperty("description"), "Nested MultiGeometry structure");
+        assertEquals(feature.getDescription(), "Nested MultiGeometry structure");
         assertEquals(feature.getGeometry().getGeometryType(), "MultiGeometry");
         ArrayList<KmlGeometry> objects = (ArrayList<KmlGeometry>) feature.getGeometry().getGeometryObject();
         assertEquals(objects.get(0).getGeometryType(), "Point");


### PR DESCRIPTION
cc @roman-mazur @Vandalko 

Without this changes KML parser add `description` field from `ExtraData` and `description` field from `placemark` element into the same hash map with the same key. With modification description in the second case is set to dedicated field in `KmlPlacemark` 
